### PR TITLE
change img to div

### DIFF
--- a/src/Note/Note.js
+++ b/src/Note/Note.js
@@ -53,7 +53,7 @@ export function Note({
       <div className={"note" + (selected ? " selected" : "")} {...props}>
         <div className={"note-content" + (selected ? " selected" : "")}>
           <div className="note-top-row">
-            <img
+            <div
               className="pin-color"
               alt=""
               style={{ backgroundColor: pin.color }}


### PR DESCRIPTION
Hello! This is Carson's roommate, and the dang circles for icons in "notes" which should probably be called "comments", have black lines through them because they were an Img element and not a div. i changed that because i needed to procrastinate from doing AI homework.

